### PR TITLE
Add support for customized/default Scalar,

### DIFF
--- a/lib/reducer.ts
+++ b/lib/reducer.ts
@@ -10,7 +10,9 @@ import {
     isIntrospectionInputValue,
     isIntrospectionListTypeRef,
     isIntrospectionObjectType,
-    isNonNullIntrospectionType
+    isNonNullIntrospectionType,
+    isIntrospectionScalarType,
+    isIntrospectionDefaultScalarType
 } from './typeGuards';
 import { graphqlToJSONType, typesMapping } from './typesMapping';
 
@@ -122,6 +124,17 @@ export const introspectionTypeReducer:
                         description: item.description || undefined
                     };
                 }),
+            };
+        }else if(isIntrospectionDefaultScalarType(curr)){
+            acc[curr.name] = {
+                type: (typesMapping as any)[curr.name],
+                title: curr.name
+            }
+        } 
+        else if (isIntrospectionScalarType(curr)){
+            acc[curr.name] = {
+                type: 'object',
+                title: curr.name
             };
         }
 

--- a/lib/typeGuards.ts
+++ b/lib/typeGuards.ts
@@ -11,9 +11,10 @@ import {
     IntrospectionOutputTypeRef,
     IntrospectionSchema,
     IntrospectionType,
-    IntrospectionTypeRef
+    IntrospectionTypeRef,
+    IntrospectionScalarType
 } from 'graphql';
-import { filter, has, startsWith } from 'lodash';
+import { filter, has, startsWith, includes } from 'lodash';
 
 ///////////////////
 /// Type guards ///
@@ -50,6 +51,13 @@ export const isNonNullIntrospectionType =
     (type: IntrospectionTypeRef): type is IntrospectionNonNullTypeRef<IntrospectionNamedTypeRef<IntrospectionType>> => (
         type.kind === 'NON_NULL'
     );
+export const isIntrospectionScalarType = (type: IntrospectionSchema['types'][0]): type is IntrospectionScalarType => (
+        type.kind === 'SCALAR'
+    );
+
+export const isIntrospectionDefaultScalarType = (type: IntrospectionSchema['types'][0]): type is IntrospectionScalarType => (
+        type.kind === 'SCALAR' && includes(['Boolean', 'String', 'Int', 'Float'], type.name)
+    );
 
 // Ignore all GraphQL native Scalars, directives, etc...
 export interface FilterDefinitionsTypesOptions { ignoreInternals?: boolean; }
@@ -61,7 +69,8 @@ export const filterDefinitionsTypes =
             type => (
                 (isIntrospectionObjectType(type) && !!type.fields) ||
                 (isIntrospectionInputObjectType(type) && !!type.inputFields) ||
-                (isIntrospectionEnumType(type) && !!type.enumValues)
+                (isIntrospectionEnumType(type) && !!type.enumValues) || 
+                (isIntrospectionScalarType(type) && !! type.name)
             ) &&
                 (!ignoreInternals || (ignoreInternals && !startsWith(type.name, '__')))
         );

--- a/lib/typesMapping.ts
+++ b/lib/typesMapping.ts
@@ -38,9 +38,14 @@ export const graphqlToJSONType = (k: GraphqlToJSONTypeArg): JSONSchema6 => {
         return graphqlToJSONType(k.ofType);
     } else {
         const name = (k as IntrospectionNamedTypeRef<IntrospectionInputType | IntrospectionOutputType>).name;
-        return includes(['OBJECT', 'INPUT_OBJECT', 'ENUM'], k.kind) ?
+        return includes(['OBJECT', 'INPUT_OBJECT', 'ENUM', 'SCALAR'], k.kind) ?
+            includes(['OBJECT', 'INPUT_OBJECT', 'ENUM'], k.kind) ?
             { $ref: `#/definitions/${name}` } :
             // tslint:disable-next-line:no-any
-            { type: (typesMapping as any)[name] };
+            { $ref: `#/definitions/${name}` ,
+              type: (typesMapping as any)[name] 
+            } :
+            { type: (typesMapping as any)[name]}
+            ;
     }
 };


### PR DESCRIPTION
in [Dociql](https://github.com/wayfair/dociql) it is using this package to generate JsonSchema from GraphQL schema, however, scalars are all missing when generating JsonSchema, added Scalar support by casting their `type` as `object` for customized scalar, default scalars are casted to the corresponding mapping 