### PR TITLE
fix bug with non-null lists

### DIFF
--- a/lib/reducer.ts
+++ b/lib/reducer.ts
@@ -28,16 +28,15 @@ type GetRequiredFieldsType = ReadonlyArray<
 >
 // Extract GraphQL no-nullable types
 export const getRequiredFields = (fields: GetRequiredFieldsType) =>
-  map(
-    filter(fields, (f) => {
-      // Not 100% sure if the GraphQL spec requires that NON_NULL should be
-      // the parent of LIST if it's both a NON_NULL and LIST field, but this
-      // should handle either case/implementation
-      return isIntrospectionListTypeRef(f.type)
-        ? isNonNullIntrospectionType(f.type.ofType)
-        : isNonNullIntrospectionType(f.type)
-    }),
-    (f) => f.name
+  reduce(
+    fields,
+    (acc: string[], f) => {
+      if (isNonNullIntrospectionType(f.type)) {
+          acc.push(f.name)
+      }
+      return acc
+    },
+    [],
   )
 
 export type IntrospectionFieldReducerItem =

--- a/test-utils.ts
+++ b/test-utils.ts
@@ -20,8 +20,10 @@ export const getTodoSchemaIntrospection = (): GetTodoSchemaIntrospectionResult =
             name: String!
             completed: Boolean
             color: Color
-            "A list containing colors that cannot contain nulls"
-            colors: [Color!]!
+            "A required list containing colors that cannot contain nulls"
+            requiredColors: [Color!]!
+            "A non-required list containing colors that cannot contain nulls"
+            optionalColors: [Color!]
         }
 
         """
@@ -46,6 +48,8 @@ export const getTodoSchemaIntrospection = (): GetTodoSchemaIntrospectionResult =
                 "todo identifier"
                 id: String!
                 isCompleted: Boolean=false
+                requiredStatuses: [String!]!
+                optionalStatuses: [String!]
             ): Todo!
             todos: [Todo!]!
         }
@@ -77,8 +81,20 @@ export const todoSchemaAsJsonSchema: JSONSchema6 = {
               properties: {
                 id: { type: 'string', description: 'todo identifier' },
                 isCompleted: { type: 'boolean', default: false },
+                requiredStatuses: {
+                    type: 'array',
+                    items: {
+                        type: 'string',
+                    },
+                },
+                optionalStatuses: {
+                    type: 'array',
+                    items: {
+                        type: 'string',
+                    },
+                },
               },
-              required: ['id'],
+              required: ['id', 'requiredStatuses'],
             },
             return: {
               $ref: '#/definitions/Todo',
@@ -152,13 +168,18 @@ export const todoSchemaAsJsonSchema: JSONSchema6 = {
         name: { type: 'string' },
         completed: { type: 'boolean' },
         color: { $ref: '#/definitions/Color' },
-        colors: {
-          description: 'A list containing colors that cannot contain nulls',
+        requiredColors: {
+          description: 'A required list containing colors that cannot contain nulls',
+          type: 'array',
+          items: { $ref: '#/definitions/Color' },
+        },
+        optionalColors: {
+          description: 'A non-required list containing colors that cannot contain nulls',
           type: 'array',
           items: { $ref: '#/definitions/Color' },
         },
       },
-      required: ['id', 'name', 'colors'],
+      required: ['id', 'name', 'requiredColors'],
     },
     Color: {
       type: 'string',


### PR DESCRIPTION
Consider an SDL fragment like this:
```graphql
type Foo {
  "The array of String is optional, but each element must be a String"
  bar: [String!]
}
```

The introspection query representation of this looks something like:
```js
{
  ...
  type: {
    kind: "LIST",
    type: null,
    ofType: {
      kind: "NON_NULL",
      type: null,
      ofType: {
        kind: "SCALAR",
        type: "String",
        ofType: null,
      },
    },
  },
}
```

...and the code I recently added would incorrectly consider this a `required` field.


Here's how a "required array requiring all elements to be Strings" would look:
```graphql
type Foo {
  "The array is required, and it must contain only Strings"
  bar: [String!]!
}
```

...and the introspection query, something like:
```js
{
  ...
  type: {
    kind: "NON_NULL",
    type: null,
    ofType: {
      kind: "LIST",
      type: null,
      ofType: {
        kind: "NON_NULL",
        type: null,
        ofType: {
          kind: "SCALAR",
          type: "String",
          ofType: null,
        },
      },
    },
  },
}
```

So, basically, the only check to perform is to see if the outermost type is Non-Null.