### PR TITLE
Same reducer for properties/Query/Mutation and definitions/Types

### DIFF
--- a/README.md
+++ b/README.md
@@ -25,165 +25,212 @@ const result = fromIntrospectionQuery(introspection);
 
 ## Example
 
-
 ### Input
 
 ```graphql
-type Todo {
-    id: String!
-    name: String!
-    completed: Boolean
-    color: Color
-    colors: [Color!]!
-}
+  type Todo {
+      id: String!
+      name: String!
+      completed: Boolean
+      color: Color
+      "A field that requires an argument"
+      colors(filter: [Color!]!): [Color!]!
+  }
 
-input TodoInputType {
-    name: String!
-    completed: Boolean
-    color: Color=RED
-}
+  input TodoInputType {
+      name: String!
+      completed: Boolean
+      color: Color=RED
+  }
 
-enum Color {
-  "Red color"
-  RED
-  "Green color"
-  GREEN
-}
+  enum Color {
+    "Red color"
+    RED
+    "Green color"
+    GREEN
+  }
 
-type Query {
-    todo(id: String!, isCompleted: Boolean=false): Todo
-    todos: [Todo]
-}
+  type Query {
+      "A Query with 1 required argument and 1 optional argument"
+      todo(id: String!, isCompleted: Boolean=false): Todo
+      todos: [Todo]
+  }
 
-type Mutation {
-    update_todo(id: String!, todo: TodoInputType!): Todo
-    create_todo(todo: TodoInputType!): Todo
-}
+  type Mutation {
+      "A Mutation with 1 required argument"
+      create_todo(todo: TodoInputType!): Todo
+      "A Mutation with 2 required arguments"
+      update_todo(id: String!, todo: TodoInputType!): Todo
+  }
 ```
 
 ### Output
 
 ```js
 {
-    $schema: 'http://json-schema.org/draft-06/schema#',
-    properties: {
-        Query: {
-            type: 'object',
-            properties: {
-                todo: {
-                    type: 'object',
-                    properties: {
-                        arguments: {
-                            type: 'object',
-                            properties: {
-                                id: { type: 'string' },
-                                isCompleted: {
-                                    type: 'boolean',
-                                    default: false
-                                }
-                            },
-                            required: ['id']
-                        },
-                        return: {
-                            $ref: '#/definitions/Todo'
-                        }
-                    },
-                    required: []
-                },
-                todos: {
-                    type: 'object',
-                    properties: {
-                        arguments: {
-                            type: 'object',
-                            properties: {},
-                            required: []
-                        },
-                        return: {
-                            type: 'array',
-                            items: { $ref: '#/definitions/Todo' }
-                        }
-                    },
-                    required: []
+  '$schema': 'http://json-schema.org/draft-06/schema#',
+  properties: {
+    Query: {
+      type: 'object',
+      properties: {
+        todo: {
+          description: 'A Query with 1 required argument and 1 optional argument',
+          type: 'object',
+          properties: {
+            return: { '$ref': '#/definitions/Todo' },
+            arguments: {
+              type: 'object',
+              properties: {
+                id: { '$ref': '#/definitions/String', type: 'string' },
+                isCompleted: {
+                  '$ref': '#/definitions/Boolean',
+                  type: 'boolean',
+                  default: false
                 }
-            },
-            required: []
-        },
-        Mutation: {
-            type: 'object',
-            properties: {
-                update_todo: {
-                    type: 'object',
-                    properties: {
-                        arguments: {
-                            type: 'object',
-                            properties: {
-                                id: { type: 'string' },
-                                todo: { $ref: '#/definitions/TodoInputType' }
-                            },
-                            required: ['id', 'todo']
-                        },
-                        return: {
-                            $ref: '#/definitions/Todo'
-                        }
-                    },
-                    required: []
-                },
-                create_todo: {
-                    type: 'object',
-                    properties: {
-                        arguments: {
-                            type: 'object',
-                            properties: {
-                                todo: { $ref: '#/definitions/TodoInputType' }
-                            },
-                            required: ['todo']
-                        },
-                        return: {
-                            $ref: '#/definitions/Todo'
-                        }
-                    },
-                    required: []
-                }
+              },
+              required: [ 'id' ]
             }
+          },
+          required: []
         },
-    },
-    definitions: {
-        'Todo': {
-            type: 'object',
-            properties: {
-                id: { type: 'string' },
-                name: { type: 'string' },
-                completed: { type: 'boolean' },
-                color: { $ref: '#/definitions/Color' },
-                colors: {
-                    type: 'array',
-                    items: { $ref: '#/definitions/Color' }
-                 },
-            },
-            required: ['id', 'name', 'colors']
-        },
-        'Color': {
-            type: 'string',
-            anyOf: [
-                {
-                    enum: ['RED'],
-                    title: 'Red color',
-                },
-                {
-                    enum: ['GREEN'],
-                    title: 'Green color',
-                }
-            ]
-        },
-        'TodoInputType': {
-            type: 'object',
-            properties: {
-                name: { type: 'string' },
-                completed: { type: 'boolean' },
-                color: { default: 'RED', $ref: '#/definitions/Color' },
-            },
-            required: ['name']
+        todos: {
+          type: 'object',
+          properties: {
+            return: { type: 'array', items: { '$ref': '#/definitions/Todo' } },
+            arguments: { type: 'object', properties: {}, required: [] }
+          },
+          required: []
         }
+      },
+      required: []
+    },
+    Mutation: {
+      type: 'object',
+      properties: {
+        create_todo: {
+          description: 'A Mutation with 1 required argument',
+          type: 'object',
+          properties: {
+            return: { '$ref': '#/definitions/Todo' },
+            arguments: {
+              type: 'object',
+              properties: { todo: { '$ref': '#/definitions/TodoInputType' } },
+              required: [ 'todo' ]
+            }
+          },
+          required: []
+        },
+        update_todo: {
+          description: 'A Mutation with 2 required arguments',
+          type: 'object',
+          properties: {
+            return: { '$ref': '#/definitions/Todo' },
+            arguments: {
+              type: 'object',
+              properties: {
+                id: { '$ref': '#/definitions/String', type: 'string' },
+                todo: { '$ref': '#/definitions/TodoInputType' }
+              },
+              required: [ 'id', 'todo' ]
+            }
+          },
+          required: []
+        }
+      },
+      required: []
     }
+  },
+  definitions: {
+    Todo: {
+      type: 'object',
+      properties: {
+        id: {
+          type: 'object',
+          properties: {
+            return: { '$ref': '#/definitions/String', type: 'string' },
+            arguments: { type: 'object', properties: {}, required: [] }
+          },
+          required: []
+        },
+        name: {
+          type: 'object',
+          properties: {
+            return: { '$ref': '#/definitions/String', type: 'string' },
+            arguments: { type: 'object', properties: {}, required: [] }
+          },
+          required: []
+        },
+        completed: {
+          type: 'object',
+          properties: {
+            return: { '$ref': '#/definitions/Boolean', type: 'boolean' },
+            arguments: { type: 'object', properties: {}, required: [] }
+          },
+          required: []
+        },
+        color: {
+          type: 'object',
+          properties: {
+            return: { '$ref': '#/definitions/Color' },
+            arguments: { type: 'object', properties: {}, required: [] }
+          },
+          required: []
+        },
+        colors: {
+          description: 'A field that requires an argument',
+          type: 'object',
+          properties: {
+            return: { type: 'array', items: { '$ref': '#/definitions/Color' } },
+            arguments: {
+              type: 'object',
+              properties: {
+                filter: {
+                  type: 'array',
+                  items: { '$ref': '#/definitions/Color' }
+                }
+              },
+              required: [ 'filter' ]
+            }
+          },
+          required: []
+        }
+      },
+      required: [ 'id', 'name', 'colors' ]
+    },
+    TodoInputType: {
+      type: 'object',
+      properties: {
+        name: { '$ref': '#/definitions/String', type: 'string' },
+        completed: { '$ref': '#/definitions/Boolean', type: 'boolean' },
+        color: { '$ref': '#/definitions/Color', default: 'RED' }
+      },
+      required: [ 'name' ]
+    },
+    Color: {
+      type: 'string',
+      anyOf: [
+        {
+          description: 'Red color',
+          enum: [ 'RED' ],
+          title: 'Red color'
+        },
+        {
+          description: 'Green color',
+          enum: [ 'GREEN' ],
+          title: 'Green color'
+        }
+      ]
+    },
+    String: {
+      description: 'The `String` scalar type represents textual data, represented as UTF-8 character sequences. The String type is most often used by GraphQL to represent free-form human-readable text.',
+      type: 'string',
+      title: 'String'
+    },
+    Boolean: {
+      description: 'The `Boolean` scalar type represents `true` or `false`.',
+      type: 'boolean',
+      title: 'Boolean'
+    }
+  }
 }
 ```

--- a/doc-exampleGenerator.ts
+++ b/doc-exampleGenerator.ts
@@ -1,0 +1,111 @@
+import { inspect } from 'util'
+import { spawn } from 'child_process'
+import { filter } from 'lodash'
+import {
+  buildSchema,
+  graphqlSync,
+  IntrospectionQuery,
+  getIntrospectionQuery,
+} from 'graphql'
+
+import { fromIntrospectionQuery } from './lib/fromIntrospectionQuery'
+
+const nativeScalarsToFilter = ['String', 'Int', 'Boolean']
+
+const readmeSDL: string = `
+  type Todo {
+      id: String!
+      name: String!
+      completed: Boolean
+      color: Color
+      "A field that requires an argument"
+      colors(filter: [Color!]!): [Color!]!
+  }
+
+  input TodoInputType {
+      name: String!
+      completed: Boolean
+      color: Color=RED
+  }
+
+  enum Color {
+    "Red color"
+    RED
+    "Green color"
+    GREEN
+  }
+
+  type Query {
+      "A Query with 1 required argument and 1 optional argument"
+      todo(id: String!, isCompleted: Boolean=false): Todo
+      todos: [Todo]
+  }
+
+  type Mutation {
+      "A Mutation with 1 required argument"
+      create_todo(todo: TodoInputType!): Todo
+      "A Mutation with 2 required arguments"
+      update_todo(id: String!, todo: TodoInputType!): Todo
+  }
+`
+
+const readmeSchema = buildSchema(readmeSDL)
+const introspectionQueryJSON = graphqlSync(readmeSchema, getIntrospectionQuery()).data as IntrospectionQuery
+const readmeResult = fromIntrospectionQuery(introspectionQueryJSON)
+
+// Get rid of undefined values this way
+const cleanedUpReadmeResult = JSON.parse(JSON.stringify(readmeResult))
+
+const startsWithTestGenerator = (stringToTest: string) => {
+  return (stringToLookFor: string) => stringToTest.startsWith(`${stringToLookFor}:`)
+}
+
+const keyComparator = (a: string, b: string) => {
+  // description to the top
+  if (['description'].some(startsWithTestGenerator(a))) {
+    // If the other one also satisfies the test (which is impossible, but ok) then
+    // there is no sort change
+    return ['description'].some(startsWithTestGenerator(b)) ? 0 : -1
+  }
+  if (['description'].some(startsWithTestGenerator(b))) {
+    return 1
+  }
+
+  // Native Scalars to the bottom
+  if (nativeScalarsToFilter.some(startsWithTestGenerator(a))) {
+    // If the other one also satisfies the test, then no sort change
+    return nativeScalarsToFilter.some(startsWithTestGenerator(b)) ? 0 : 1
+  }
+  if (nativeScalarsToFilter.some(startsWithTestGenerator(b))) {
+    return -1
+  }
+
+  // Stay the same
+  return 0
+}
+
+const output = `
+### Input
+
+\`\`\`graphql${readmeSDL}\`\`\`
+
+### Output
+
+\`\`\`js
+${inspect(cleanedUpReadmeResult, {depth: null, sorted: keyComparator})}
+\`\`\`
+`
+
+console.log(`
+<BEGIN OUTPUT>
+${output}
+<END OUTPUT>
+`)
+
+if (process.platform === 'darwin') {
+  const proc = spawn('pbcopy');
+  proc.stdin.write(output)
+  proc.stdin.end()
+  console.log('OUTPUT COPIED TO YOUR CLIPBOARD!!!\n')
+}
+

--- a/package.json
+++ b/package.json
@@ -14,7 +14,8 @@
   "scripts": {
     "test": "jest",
     "prettier:check": "prettier -c \"**/*.ts\"",
-    "prettier:format": "prettier -w \"**/*.ts\""
+    "prettier:format": "prettier -w \"**/*.ts\"",
+    "generateReadmeExample": "npx ts-node doc-exampleGenerator.ts"
   },
   "devDependencies": {
     "@types/ajv": "^1.0.0",

--- a/test-utils.ts
+++ b/test-utils.ts
@@ -24,6 +24,12 @@ export const getTodoSchemaIntrospection = (): GetTodoSchemaIntrospectionResult =
             requiredColors: [Color!]!
             "A non-required list containing colors that cannot contain nulls"
             optionalColors: [Color!]
+            fieldWithOptionalArgument(
+              optionalFilter: [String!]
+            ): [String!]
+            fieldWithRequiredArgument(
+              requiredFilter: [String!]!
+            ): [String!]
         }
 
         """
@@ -61,6 +67,7 @@ export const getTodoSchemaIntrospection = (): GetTodoSchemaIntrospectionResult =
 `)
 
   const result = graphqlSync(schema, getIntrospectionQuery())
+
   return {
     introspection: result.data as IntrospectionQuery,
     schema,
@@ -118,6 +125,8 @@ export const todoSchemaAsJsonSchema: JSONSchema6 = {
           required: [],
         },
       },
+      // Inappropriate for individual queries to be required, despite possibly having
+      // NON_NULL return types
       required: [],
     },
     Mutation: {
@@ -157,6 +166,9 @@ export const todoSchemaAsJsonSchema: JSONSchema6 = {
           required: [],
         },
       },
+      // Inappropriate for individual mutations to be required, despite possibly having
+      // NON_NULL return types
+      required: [],
     },
   },
   definitions: {
@@ -164,22 +176,104 @@ export const todoSchemaAsJsonSchema: JSONSchema6 = {
       type: 'object',
       description: 'A ToDo Object',
       properties: {
-        id: { type: 'string', description: 'A unique identifier' },
-        name: { type: 'string' },
-        completed: { type: 'boolean' },
-        color: { $ref: '#/definitions/Color' },
+        id: {
+          description: 'A unique identifier',
+          type: 'object',
+          properties: {
+            return: { type: 'string' },
+            arguments: { type: 'object', properties: {}, required: [] }
+          },
+          required: [],
+        },
+        name: {
+          type: 'object',
+          properties: {
+            return: { type: 'string' },
+            arguments: { type: 'object', properties: {}, required: [] }
+          },
+          required: [],
+        },
+        completed: {
+          type: 'object',
+          properties: {
+            return: { type: 'boolean' },
+            arguments: { type: 'object', properties: {}, required: [] }
+          },
+          required: [],
+        },
+        color: {
+          type: 'object',
+          properties: {
+            return: { $ref: '#/definitions/Color' },
+            arguments: { type: 'object', properties: {}, required: [] },
+          },
+          required: [],
+        },
         requiredColors: {
-          description:
-            'A required list containing colors that cannot contain nulls',
-          type: 'array',
-          items: { $ref: '#/definitions/Color' },
+          description: 'A required list containing colors that cannot contain nulls',
+          type: 'object',
+          properties: {
+            return: {
+              type: 'array',
+              items: { $ref: '#/definitions/Color' },
+            },
+            arguments: { type: 'object', properties: {}, required: [] }
+          },
+          required: [],
         },
         optionalColors: {
           description:
             'A non-required list containing colors that cannot contain nulls',
-          type: 'array',
-          items: { $ref: '#/definitions/Color' },
+          type: 'object',
+          properties: {
+            return: {
+              type: 'array',
+              items: { $ref: '#/definitions/Color' },
+            },
+            arguments: { type: 'object', properties: {}, required: [] },
+          },
+          required: [],
         },
+        fieldWithOptionalArgument: {
+          type: 'object',
+          properties: {
+            return: {
+              type: 'array',
+              items: { type: 'string' },
+            },
+            arguments: {
+              type: 'object',
+              properties: {
+                optionalFilter: {
+                  type: 'array',
+                  items: { type: 'string' },
+                }
+              },
+              required: [],
+            },
+          },
+          required: [],
+        },
+        fieldWithRequiredArgument: {
+          type: 'object',
+          properties: {
+            return: {
+              type: 'array',
+              items: { type: 'string' },
+            },
+            arguments: {
+              type: 'object',
+              properties: {
+                requiredFilter: {
+                  type: 'array',
+                  items: { type: 'string' },
+                }
+              },
+              required: ['requiredFilter'],
+            },
+          },
+          required: [],
+        }
       },
       required: ['id', 'name', 'requiredColors'],
     },


### PR DESCRIPTION
See #28 for more details, but this PR:

1. Treats non-`Query/Mutation Type`s very similarly to how `Query/Mutation Type`s are treated. Notable exceptions being:
  1. `Query/Mutation` ones still end up in `properties` while non-`Query/Mutation` ones end up in `definitions`
  2. The resulting `Query` and `Mutation` entries in `properties` will _still_ never have any required fields.
1. Created a `doc-generateExample.ts` script (and corresponding `package.json` `scripts:` entry) to generate a copy/paste-able example for the README. This way, if we assume that the library is working correctly, we don't need to write out the changes by hand: simply alter the input SDL, run the script, and get all the output we need.

Resolves #28 