### PR TITLE
Change node engine requirement to ">=8" and update tsconfig accordingly

### DIFF
--- a/package.json
+++ b/package.json
@@ -6,7 +6,7 @@
   "author": "Charly POLY <cpoly55@gmail.com>",
   "license": "MIT",
   "engines": {
-    "node": "^14"
+    "node": ">=8"
   },
   "dependencies": {
     "lodash": "^4.17.20"

--- a/tsconfig.json
+++ b/tsconfig.json
@@ -1,12 +1,23 @@
 {
-    "compilerOptions": {
-        "module": "commonjs",
-        "noImplicitAny": true,
-        "removeComments": true,
-        "skipLibCheck": true,
-        "strict": true,
-        "declaration": true,
-        "outDir": "./dist",
-        "rootDir": "."
-    }
+  "$schema": "https://json.schemastore.org/tsconfig",
+  "display": "Node 8",
+
+  "compilerOptions": {
+    // https://www.typescriptlang.org/tsconfig#target
+    // ES6/ES2015 features are supported by Node v8
+    "target": "ES2015",
+    "lib": ["ES2015"],
+
+    "module": "commonjs",
+    "strict": true,
+    "declaration": true,
+    "removeComments": true,
+    "esModuleInterop": true,
+    "noImplicitAny": true,
+    "skipLibCheck": true,
+    "forceConsistentCasingInFileNames": true,
+
+    "outDir": "./dist",
+    "rootDir": "."
+  },
 }


### PR DESCRIPTION
When using this package as a dependency in a project that  a version of Node that's less than 14, I received the following error:
```bash
error graphql-2-json-schema@0.3.1: The engine "node" is incompatible with this module. Expected version "^14". Got "8.17.0"
error Found incompatible module.
```

I think the issue is that [this change](https://github.com/wittydeveloper/graphql-to-json-schema/commit/4f7acb5358620da43438d4ce555c356aa854c144#diff-7ae45ad102eab3b6d7e7896acd08c427a9b25b346470d7bc6507b6481575d519R9). While the other version-related changes enforce/encourage **_development_** of this package using Node `v14`, the `package.json.engines.node` entry defines requirements for this package to _**run**_.

Assuming that the release process includes a `tsc` compilation using the `tsconfig.json` in this repo, the resulting `.js` files were already being transpiled for [`ES3` targets](https://www.typescriptlang.org/tsconfig#target) (it's the default).

However, since `ES3` is as old as dirt, and since the docs say the following:
> Modern browsers support all ES6 features, so ES6 is a good choice.

I figured we may as well use a target of `ES6`/`ES2015` since Node [`v8.0+` appears to support](url) just about all of its features. Actually, it looks probably safe to go back as far as `v6.5+`, but I think anyone who's touching their dependencies these days will be running at least `8`.

So, I set the `engines.node` to `>=8` and explicitly compile the `ts` down to `ES2015`.