### PR TITLE
add a 'prepare' script to package.json

### DIFF
--- a/package.json
+++ b/package.json
@@ -15,7 +15,8 @@
     "test": "jest",
     "prettier:check": "prettier -c \"**/*.ts\"",
     "prettier:format": "prettier -w \"**/*.ts\"",
-    "generateReadmeExample": "npx ts-node doc-exampleGenerator.ts"
+    "generateReadmeExample": "npx ts-node doc-exampleGenerator.ts",
+    "prepare": "npx tsc"
   },
   "devDependencies": {
     "@types/ajv": "^1.0.0",


### PR DESCRIPTION
Added a `"prepare"` script to `package.json`. Has a lot of advantages that can be seen here:
https://docs.npmjs.com/cli/v6/using-npm/scripts#life-cycle-scripts

Mostly, though:
- Good for `npm publish`
- Good for anyone who wants to specify the dependency via git, as it will "build" the `/dist` stuff.